### PR TITLE
feat: Improve ji init command with smart project detection

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -3,6 +3,7 @@ import { stdin as input, stdout as output } from 'node:process';
 import * as readline from 'node:readline/promises';
 import chalk from 'chalk';
 import { Console, Effect, pipe } from 'effect';
+import { CacheManager } from '../../lib/cache.js';
 import { type Config, ConfigManager } from '../../lib/config.js';
 
 // Effect wrapper for readline operations with default value
@@ -489,13 +490,57 @@ const setupEffect = (rl: readline.Interface) =>
 
     // Step 4: Initial sync
     Effect.flatMap(() => Console.log(chalk.bold('\nStep 4: Initial Sync'))),
-    Effect.flatMap(() => Console.log("Let's set up your first Jira project.")),
-    Effect.flatMap(() => askQuestionWithDefault('Project key (e.g., PROJ)', undefined, rl)),
-    Effect.flatMap((projectKey) => {
-      if (projectKey && typeof projectKey === 'string' && projectKey.trim()) {
-        return showSyncInstructions(projectKey.trim().toUpperCase());
+    Effect.flatMap(() =>
+      Effect.tryPromise({
+        try: async () => {
+          const cacheManager = new CacheManager();
+          try {
+            const projects = await cacheManager.getAllProjects();
+            return projects;
+          } finally {
+            cacheManager.close();
+          }
+        },
+        catch: () => [],
+      }),
+    ),
+    Effect.flatMap((existingProjects) => {
+      if (existingProjects.length > 0) {
+        return pipe(
+          Console.log(chalk.cyan('Found existing synced projects:')),
+          Effect.flatMap(() =>
+            Effect.all(
+              existingProjects.slice(0, 5).map((project) => {
+                const syncInfo = project.lastSync
+                  ? chalk.dim(` - ${project.issueCount} issues, last synced ${project.lastSync.toLocaleDateString()}`)
+                  : chalk.dim(' - not synced yet');
+                return Console.log(`  ${chalk.bold(project.key)} ${project.name}${syncInfo}`);
+              }),
+            ),
+          ),
+          Effect.flatMap(() => {
+            if (existingProjects.length > 5) {
+              return Console.log(chalk.dim(`  ... and ${existingProjects.length - 5} more projects`));
+            }
+            return Effect.succeed(undefined);
+          }),
+          Effect.flatMap(() => Console.log('\nYou can sync more projects later with:')),
+          Effect.flatMap(() => Console.log(chalk.cyan('  ji issue sync <project-key>'))),
+          Effect.flatMap(() => Console.log('\nOr sync all active workspaces with:')),
+          Effect.flatMap(() => Console.log(chalk.cyan('  ji sync'))),
+        );
       } else {
-        return Console.log(chalk.dim('Skipping project setup'));
+        return pipe(
+          Console.log("Let's set up your first Jira project."),
+          Effect.flatMap(() => askQuestionWithDefault('Project key (e.g., PROJ)', undefined, rl)),
+          Effect.flatMap((projectKey) => {
+            if (projectKey && typeof projectKey === 'string' && projectKey.trim()) {
+              return showSyncInstructions(projectKey.trim().toUpperCase());
+            } else {
+              return Console.log(chalk.dim('Skipping project setup'));
+            }
+          }),
+        );
       }
     }),
 

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -1,3 +1,5 @@
+import { stdin as input, stdout as output } from 'node:process';
+import * as readline from 'node:readline/promises';
 import chalk from 'chalk';
 import { Console, Effect, pipe } from 'effect';
 import { CacheManager } from '../../lib/cache.js';
@@ -48,7 +50,7 @@ const syncIssuesBatch = (issues: Issue[], cacheManager: CacheManager, contentMan
 const syncJiraProjectEffect = (projectKey: string, options: { fresh?: boolean; clean?: boolean } = {}) =>
   pipe(
     getManagersEffect(),
-    Effect.flatMap(({ config, configManager, cacheManager, contentManager, jiraClient }) =>
+    Effect.flatMap(({ configManager, cacheManager, contentManager, jiraClient }) =>
       pipe(
         // If clean flag is set, delete existing issues first
         options.clean
@@ -103,7 +105,6 @@ const syncJiraProjectEffect = (projectKey: string, options: { fresh?: boolean; c
             Effect.flatMap(() => {
               let totalSynced = 0;
               const batchSize = 50;
-              const issuesBatch: Issue[] = [];
 
               return pipe(
                 jiraClient.getAllProjectIssuesEffect(projectKey, {
@@ -157,6 +158,13 @@ const syncJiraProjectEffect = (projectKey: string, options: { fresh?: boolean; c
                 ),
               ),
             ),
+            // Track this project as a workspace
+            Effect.tap(() =>
+              Effect.tryPromise({
+                try: () => cacheManager.trackWorkspace('jira_project', projectKey, projectKey),
+                catch: (error) => new Error(`Failed to track workspace: ${error}`),
+              }),
+            ),
             Effect.tap(() =>
               Effect.sync(() => {
                 cacheManager.close();
@@ -184,9 +192,134 @@ export async function syncJiraProject(projectKey: string, options: { fresh?: boo
   }
 }
 
-export async function syncWorkspaces(_options: { clean?: boolean } = {}) {
-  console.log(chalk.yellow('syncWorkspaces - Not yet implemented'));
-  console.log(chalk.dim('This will sync all your active workspaces in the future.'));
+// Pure Effect-based syncWorkspaces implementation
+const syncWorkspacesEffect = (options: { clean?: boolean } = {}) =>
+  pipe(
+    Effect.tryPromise({
+      try: async () => {
+        const cacheManager = new CacheManager();
+        try {
+          const workspaces = await cacheManager.getActiveWorkspaces();
+          return { cacheManager, workspaces };
+        } catch (error) {
+          cacheManager.close();
+          throw error;
+        }
+      },
+      catch: (error) => new Error(`Failed to get active workspaces: ${error}`),
+    }),
+    Effect.flatMap(({ cacheManager, workspaces }) => {
+      const jiraProjects = workspaces.filter((w) => w.type === 'jira_project');
+      const confluenceSpaces = workspaces.filter((w) => w.type === 'confluence_space');
+
+      if (workspaces.length === 0) {
+        return pipe(
+          Console.log(chalk.yellow('No active workspaces found.')),
+          Effect.flatMap(() => Console.log(chalk.dim('Sync projects with: ji issue sync <project-key>'))),
+          Effect.tap(() => Effect.sync(() => cacheManager.close())),
+        );
+      }
+
+      return pipe(
+        Console.log(chalk.bold('Active Workspaces:')),
+        Effect.flatMap(() => {
+          const effects: Effect.Effect<void, Error>[] = [];
+
+          if (jiraProjects.length > 0) {
+            effects.push(
+              pipe(
+                Console.log(chalk.cyan('\nJira Projects:')),
+                Effect.flatMap(() =>
+                  Effect.all(
+                    jiraProjects.map((project) => {
+                      const lastUsed = new Date(project.lastUsed).toLocaleDateString();
+                      const usageInfo = chalk.dim(` (used ${project.usageCount} times, last: ${lastUsed})`);
+                      return Console.log(`  ${chalk.bold(project.keyOrId)} - ${project.name}${usageInfo}`);
+                    }),
+                  ),
+                ),
+              ),
+            );
+          }
+
+          if (confluenceSpaces.length > 0) {
+            effects.push(
+              pipe(
+                Console.log(chalk.cyan('\nConfluence Spaces:')),
+                Effect.flatMap(() =>
+                  Effect.all(
+                    confluenceSpaces.map((space) => {
+                      const lastUsed = new Date(space.lastUsed).toLocaleDateString();
+                      const usageInfo = chalk.dim(` (used ${space.usageCount} times, last: ${lastUsed})`);
+                      return Console.log(`  ${chalk.bold(space.keyOrId)} - ${space.name}${usageInfo}`);
+                    }),
+                  ),
+                ),
+              ),
+            );
+          }
+
+          return Effect.all(effects, { concurrency: 1 });
+        }),
+        Effect.flatMap(() => {
+          const rl = readline.createInterface({ input, output });
+          return pipe(
+            Effect.tryPromise({
+              try: async () => {
+                const defaultText = 'Y/n';
+                const answer = await rl.question(
+                  `\nWould you like to sync all Jira projects now? ${chalk.dim(`[${defaultText}]`)}: `,
+                );
+                const normalized = answer.trim().toLowerCase();
+                return !normalized ? true : normalized === 'y' || normalized === 'yes';
+              },
+              catch: (error) => new Error(`Failed to get user input: ${error}`),
+            }),
+            Effect.tap(() => Effect.sync(() => rl.close())),
+          );
+        }),
+        Effect.flatMap((shouldSync) => {
+          if (!shouldSync) {
+            return Console.log(chalk.dim('Skipping sync'));
+          }
+
+          return pipe(
+            Console.log(chalk.cyan('\nSyncing Jira projects...')),
+            Effect.flatMap(() =>
+              Effect.all(
+                jiraProjects.map((project, index) =>
+                  pipe(
+                    Console.log(chalk.dim(`\n[${index + 1}/${jiraProjects.length}] Syncing ${project.keyOrId}...`)),
+                    Effect.flatMap(() => {
+                      // Close current cache manager before syncing each project
+                      cacheManager.close();
+                      return syncJiraProjectEffect(project.keyOrId, options);
+                    }),
+                  ),
+                ),
+                { concurrency: 1 }, // Sync one at a time
+              ),
+            ),
+            Effect.tap(() => Console.log(chalk.green('\n✓ All projects synced successfully!'))),
+          );
+        }),
+        Effect.tap(() => Effect.sync(() => cacheManager.close())),
+      );
+    }),
+    Effect.catchAll((error) =>
+      pipe(
+        Console.error(chalk.red('Sync failed:'), error instanceof Error ? error.message : String(error)),
+        Effect.flatMap(() => Effect.fail(error)),
+      ),
+    ),
+  );
+
+export async function syncWorkspaces(options: { clean?: boolean } = {}) {
+  try {
+    await Effect.runPromise(syncWorkspacesEffect(options));
+  } catch (_error) {
+    process.exit(1);
+  }
 }
 
 export async function syncConfluence(spaceKey: string, _options: { clean?: boolean } = {}) {

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -572,6 +572,34 @@ export class CacheManager {
     stmt.run(autoSync ? 1 : 0, autoSync, Date.now(), id);
   }
 
+  async getAllProjects(): Promise<Array<{ key: string; name: string; issueCount?: number; lastSync?: Date }>> {
+    const stmt = this.db.prepare(`
+      SELECT 
+        p.key, 
+        p.name,
+        COUNT(i.key) as issue_count,
+        MAX(i.synced_at) as last_sync
+      FROM projects p
+      LEFT JOIN issues i ON p.key = i.project_key
+      GROUP BY p.key, p.name
+      ORDER BY last_sync DESC, p.key ASC
+    `);
+
+    const rows = stmt.all() as Array<{
+      key: string;
+      name: string;
+      issue_count: number;
+      last_sync: number | null;
+    }>;
+
+    return rows.map((row) => ({
+      key: row.key,
+      name: row.name,
+      issueCount: row.issue_count,
+      lastSync: row.last_sync ? new Date(row.last_sync) : undefined,
+    }));
+  }
+
   // Sprint management methods
   async trackUserSprint(
     userEmail: string,


### PR DESCRIPTION
## Summary

This PR improves the `ji init` command to be smarter about project setup by detecting existing synced projects and providing better workspace tracking.

## Changes

1. **Added `getAllProjects()` method to CacheManager**
   - Lists all synced projects with issue counts and last sync dates
   - Orders by most recently synced first

2. **Enhanced init command**
   - Detects when projects are already synced
   - Shows existing projects instead of asking for a new one
   - Displays project statistics (issue count, last sync date)
   - Provides clear next steps for syncing more projects

3. **Workspace tracking**
   - Automatically tracks projects as workspaces when syncing
   - Records usage count and last used timestamp

4. **Implemented `ji sync` command**
   - Shows all active workspaces with usage statistics
   - Allows batch syncing of all active Jira projects
   - Interactive confirmation before syncing

## Example Output

### When running `ji init` with existing projects:
```
Step 4: Initial Sync
Found existing synced projects:
  EVAL Evaluation - 45 issues, last synced 1/2/2025
  DEV Development - 123 issues, last synced 12/28/2024
  TEST Testing - 67 issues, last synced 12/25/2024

You can sync more projects later with:
  ji issue sync <project-key>

Or sync all active workspaces with:
  ji sync
```

### When running `ji sync`:
```
Active Workspaces:

Jira Projects:
  EVAL - Evaluation (used 15 times, last: 1/2/2025)
  DEV - Development (used 8 times, last: 12/28/2024)

Would you like to sync all Jira projects now? [Y/n]: y

Syncing Jira projects...
[1/2] Syncing EVAL...
✓ Successfully synced 45 issues from EVAL
[2/2] Syncing DEV...
✓ Successfully synced 123 issues from DEV

✓ All projects synced successfully\!
```

## Benefits

- **No duplicate work**: If you've already synced projects, init won't ask you to sync again
- **Better visibility**: Users can see what projects are already in their local database
- **Workspace tracking**: The system remembers which projects are used most frequently
- **Batch operations**: The `ji sync` command makes it easy to keep all projects up to date

## Testing

- All TypeScript types check correctly
- Code passes linting with only pre-existing warnings
- Uses Effect library for proper error handling throughout

🤖 Generated with [Claude Code](https://claude.ai/code)