### PR TITLE
refactor: rename --sync flag to --fetch for clarity

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,14 +56,14 @@ ${chalk.yellow('Subcommands:')}
 
 ${chalk.yellow('Options:')}
   --json                    Output in JSON format (for view)
-  --sync                    Fetch fresh data from API (for view)
+  --fetch                   Fetch fresh data from API (for view)
   --clean                   Clean sync - remove existing issues first
   --help                    Show this help message
 
 ${chalk.yellow('Examples:')}
   ji issue view EVAL-123
   ji issue view EVAL-123 --json
-  ji issue view EVAL-123 --sync
+  ji issue view EVAL-123 --fetch
   ji issue sync EVAL --clean
 `);
 }
@@ -708,7 +708,7 @@ async function main() {
         }
 
         if (subArgs[0] === 'view' && subArgs[1]) {
-          await viewIssue(subArgs[1], { json: args.includes('--json'), sync: args.includes('--sync') });
+          await viewIssue(subArgs[1], { json: args.includes('--json'), sync: args.includes('--fetch') });
         } else if (subArgs[0] === 'sync' && subArgs[1]) {
           await syncJiraProject(subArgs[1], { clean: args.includes('--clean') });
         } else {
@@ -903,7 +903,7 @@ async function main() {
       default:
         // Check if it's an issue key (e.g., ABC-123)
         if (/^[A-Z]+-\d+$/.test(command)) {
-          await viewIssue(command, { json: args.includes('--json'), sync: args.includes('--sync') });
+          await viewIssue(command, { json: args.includes('--json'), sync: args.includes('--fetch') });
         } else {
           console.error(`Unknown command: ${command}`);
           console.log('Run "ji help" for usage information');

--- a/src/test/issue-comments-sync.test.ts
+++ b/src/test/issue-comments-sync.test.ts
@@ -163,28 +163,28 @@ describe('Issue Comments Sync', () => {
     }
   });
 
-  test('CLI recognizes --sync flag for issue view command', () => {
+  test('CLI recognizes --fetch flag for issue view command', () => {
     // This test verifies the CLI parsing logic
-    const testArgs = ['issue', 'view', 'TEST-123', '--sync'];
+    const testArgs = ['issue', 'view', 'TEST-123', '--fetch'];
 
     // Simulate argument parsing
-    const hasSync = testArgs.includes('--sync');
+    const hasFetch = testArgs.includes('--fetch');
     const hasJson = testArgs.includes('--json');
 
-    expect(hasSync).toBe(true);
+    expect(hasFetch).toBe(true);
     expect(hasJson).toBe(false);
   });
 
-  test('CLI recognizes --sync flag for direct issue key command', () => {
-    // Test for the shorthand ji TEST-123 --sync
-    const testArgs = ['TEST-123', '--sync'];
+  test('CLI recognizes --fetch flag for direct issue key command', () => {
+    // Test for the shorthand ji TEST-123 --fetch
+    const testArgs = ['TEST-123', '--fetch'];
 
     // Check if it's an issue key
     const isIssueKey = /^[A-Z]+-\d+$/.test(testArgs[0]);
-    const hasSync = testArgs.includes('--sync');
+    const hasFetch = testArgs.includes('--fetch');
 
     expect(isIssueKey).toBe(true);
-    expect(hasSync).toBe(true);
+    expect(hasFetch).toBe(true);
   });
 
   test('ISSUE_FIELDS constant includes comment field', () => {


### PR DESCRIPTION
## Summary
- Renamed `--sync` flag to `--fetch` in `ji issue view` and `ji <issue-key>` commands
- Updated help text and documentation
- Updated all tests to use the new flag name

## Rationale
The `--fetch` flag better communicates its purpose: fetching fresh data from the API rather than using cached data. The term "fetch" is clearer and more intuitive than "sync" in this context.

## Changes
- CLI now accepts `--fetch` instead of `--sync` (e.g., `ji issue view EVAL-123 --fetch`)
- Help text updated to show `--fetch` in examples
- Test descriptions and cases updated to use `--fetch`
- Internal parameter name kept as `sync` for backward compatibility at the function level

## Test plan
- [x] Run `bun test` to verify all tests pass
- [x] Test `ji issue view EVAL-5767 --fetch` to fetch fresh data with comments
- [x] Test `ji EVAL-5767 --fetch` shorthand command
- [x] Verify help text shows correct flag with `ji issue --help`

🤖 Generated with [Claude Code](https://claude.ai/code)