### PR TITLE
feat: make issue viewing remote-first with XML output (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ A fast, modern CLI for Jira and Confluence built with Bun and TypeScript. Featur
 
 ## Local-First Architecture
 
-**ji** is designed as a local-first application. This means:
+**ji** provides a hybrid approach for optimal performance:
 
-- **Instant responses** - All commands return cached data immediately from your local SQLite database
-- **Background sync** - Data updates happen silently in the background without blocking your workflow
-- **Sync transparency** - Every response includes a `# Last synced:` indicator showing data freshness
-- **Zero waiting** - No spinners, no progress bars, just instant results
-- **Offline capable** - Full functionality even without network access
+- **Remote-first for issues** - `ji PROJ-123` fetches fresh data from Jira by default
+- **Local-first for search** - Search and list operations use SQLite for instant results  
+- **XML output format** - Structured XML output optimized for LLM parsing
+- **Offline mode** - Add `--local` flag to any command to use cached data
+- **Background sync** - Data updates happen silently in the background
 
-When you run commands like `ji mine`, you get results instantly from your local cache. The data age is always visible, and fresh data syncs automatically in the background.
+Issue viewing commands fetch fresh data by default, ensuring you always see the latest status. Use `--local` for instant offline access when needed.
 
 ## Installation
 

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -6,6 +6,16 @@ import { type Issue, JiraClient } from '../../lib/jira-client.js';
 import { formatSmartDate } from '../../lib/utils/date-formatter.js';
 import { formatDescription } from '../formatters/issue.js';
 
+// Helper function to escape XML special characters
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
 // Effect wrapper for getting configuration and managers
 const getManagersEffect = () =>
   Effect.tryPromise({
@@ -80,31 +90,32 @@ const refreshInBackgroundEffect = (_config: { jiraUrl: string }, issue: Issue) =
     catch: (error) => new Error(`Failed to trigger background refresh: ${error}`),
   });
 
-// Effect for formatting issue output in YAML format
+// Effect for formatting issue output in XML format for better LLM parsing
 const formatIssueOutputEffect = (issue: Issue, config: { jiraUrl: string }) =>
   Effect.sync(() => {
-    // YAML output with color highlighting (matching search results)
-    console.log(`type: issue`);
-    console.log(`key: ${issue.key}`);
-    console.log(`link: ${config.jiraUrl}/browse/${issue.key}`);
-    console.log(`title: ${issue.fields.summary}`);
-    console.log(`updated: ${formatSmartDate(issue.fields.updated)}`);
-    console.log(`created: ${formatSmartDate(issue.fields.created)}`);
-    console.log(`status: ${issue.fields.status.name}`);
+    // XML output for better LLM parsing
+    console.log('<issue>');
+    console.log(`  <type>issue</type>`);
+    console.log(`  <key>${issue.key}</key>`);
+    console.log(`  <link>${config.jiraUrl}/browse/${issue.key}</link>`);
+    console.log(`  <title>${escapeXml(issue.fields.summary)}</title>`);
+    console.log(`  <updated>${formatSmartDate(issue.fields.updated)}</updated>`);
+    console.log(`  <created>${formatSmartDate(issue.fields.created)}</created>`);
+    console.log(`  <status>${escapeXml(issue.fields.status.name)}</status>`);
 
     // Priority
     if (issue.fields.priority) {
       const priority = issue.fields.priority.name;
-      console.log(`priority: ${priority}`);
+      console.log(`  <priority>${escapeXml(priority)}</priority>`);
     }
 
     // Reporter before Assignee
-    console.log(`reporter: ${issue.fields.reporter.displayName}`);
+    console.log(`  <reporter>${escapeXml(issue.fields.reporter.displayName)}</reporter>`);
 
     if (issue.fields.assignee) {
-      console.log(`assignee: ${issue.fields.assignee.displayName}`);
+      console.log(`  <assignee>${escapeXml(issue.fields.assignee.displayName)}</assignee>`);
     } else {
-      console.log(`assignee: Unassigned`);
+      console.log(`  <assignee>Unassigned</assignee>`);
     }
 
     // Sprint information
@@ -128,22 +139,23 @@ const formatIssueOutputEffect = (issue: Issue, config: { jiraUrl: string }) =>
       } else if (sprintField && typeof sprintField === 'object' && 'name' in sprintField) {
         sprintName = (sprintField as { name: string }).name;
       }
-      console.log(`sprint: ${sprintName}`);
+      console.log(`  <sprint>${escapeXml(sprintName)}</sprint>`);
     }
 
     // Labels
     if (issue.fields.labels && issue.fields.labels.length > 0) {
-      console.log(`labels: ${issue.fields.labels.join(', ')}`);
+      console.log(`  <labels>`);
+      issue.fields.labels.forEach((label) => {
+        console.log(`    <label>${escapeXml(label)}</label>`);
+      });
+      console.log(`  </labels>`);
     }
 
     // Description - always show full description
     const description = formatDescription(issue.fields.description);
     if (description.trim()) {
       const cleanDescription = description.replace(/\s+/g, ' ').trim();
-
-      console.log(`description: |`);
-      // For YAML pipe literal, keep as single paragraph (no artificial line breaks)
-      console.log(`  ${cleanDescription}`);
+      console.log(`  <description>${escapeXml(cleanDescription)}</description>`);
     }
 
     // Comments - show all comments
@@ -159,33 +171,36 @@ const formatIssueOutputEffect = (issue: Issue, config: { jiraUrl: string }) =>
       ).comments;
 
       if (comments.length > 0) {
-        console.log(`comments:`);
+        console.log(`  <comments>`);
 
-        // Show all comments as YAML array
+        // Show all comments in XML format
         comments.forEach((comment) => {
           const commentBody = formatDescription(comment.body).replace(/\s+/g, ' ').trim();
-          console.log(`  - author: ${comment.author.displayName}`);
-          console.log(`    created: ${formatSmartDate(comment.created)}`);
-          console.log(`    body: |`);
-
-          // For YAML pipe literal, keep as single paragraph (no artificial line breaks)
-          console.log(`      ${commentBody}`);
+          console.log(`    <comment>`);
+          console.log(`      <author>${escapeXml(comment.author.displayName)}</author>`);
+          console.log(`      <created>${formatSmartDate(comment.created)}</created>`);
+          console.log(`      <body>${escapeXml(commentBody)}</body>`);
+          console.log(`    </comment>`);
         });
+        console.log(`  </comments>`);
       }
     }
+
+    // Close the issue XML tag
+    console.log('</issue>');
   });
 
-// Pure Effect-based viewIssue implementation - local-first approach
-const viewIssueEffect = (issueKey: string, options: { json?: boolean; sync?: boolean } = {}) =>
+// Pure Effect-based viewIssue implementation - remote-first approach
+const viewIssueEffect = (issueKey: string, options: { json?: boolean; local?: boolean } = {}) =>
   pipe(
     getManagersEffect(),
     Effect.flatMap(({ config, configManager, cacheManager, contentManager, jiraClient }) =>
       pipe(
-        // First, try to get from cache (local-first approach)
+        // Check if we should use local cache or fetch fresh data
         getCachedIssueEffect(cacheManager, issueKey),
         Effect.flatMap((cachedIssue) => {
-          if (cachedIssue && !options.sync) {
-            // We have cached data, use it immediately (local-first)
+          if (options.local && cachedIssue) {
+            // User explicitly requested local cached data
             return pipe(
               formatIssueOutputEffect(cachedIssue, config),
               // Optionally refresh in background for next time
@@ -199,7 +214,7 @@ const viewIssueEffect = (issueKey: string, options: { json?: boolean; sync?: boo
               ),
             );
           } else {
-            // No cached data or user requested fresh sync - fetch from API
+            // Default behavior: fetch fresh data from API
             return pipe(
               getIssueFromJiraEffect(jiraClient, issueKey),
               Effect.flatMap((issue) =>
@@ -255,7 +270,7 @@ const viewIssueEffect = (issueKey: string, options: { json?: boolean; sync?: boo
     ),
   );
 
-export async function viewIssue(issueKey: string, options: { json?: boolean; sync?: boolean } = {}) {
+export async function viewIssue(issueKey: string, options: { json?: boolean; local?: boolean } = {}) {
   try {
     await Effect.runPromise(viewIssueEffect(issueKey, options));
   } catch (_error) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -55,15 +55,19 @@ ${chalk.yellow('Subcommands:')}
 
 ${chalk.yellow('Options:')}
   --json                    Output in JSON format (for view)
-  --fetch                   Fetch fresh data from API (for view)
+  --local                   Use cached data instead of fetching from API
   --clean                   Clean sync - remove existing issues first
   --help                    Show this help message
 
+${chalk.yellow('Note:')}
+  By default, 'ji issue view' fetches fresh data from Jira.
+  Use --local to view cached data for offline/faster access.
+
 ${chalk.yellow('Examples:')}
-  ji issue view EVAL-123
-  ji issue view EVAL-123 --json
-  ji issue view EVAL-123 --fetch
-  ji issue sync EVAL --clean
+  ji issue view EVAL-123          # Fetches fresh data from Jira
+  ji issue view EVAL-123 --local  # Uses cached data
+  ji issue view EVAL-123 --json   # Fresh data in JSON format
+  ji issue sync EVAL --clean      # Sync all issues from project
 `);
 }
 
@@ -491,7 +495,8 @@ ${chalk.yellow('Issues:')}
   ji open <issue-key>                  Open issue in browser
   ji comment <issue-key> [comment]     Add a comment to an issue
   ji log <issue-key>                   Interactive comment viewer/editor
-  ji <issue-key>                       View issue details
+  ji <issue-key>                       View issue (fetches fresh data)
+  ji <issue-key> --local               View issue (cached data)
   ji issue view <issue-key>            View issue details (alias)
   ji issue sync <project-key>          Sync all issues from a project
 
@@ -687,7 +692,7 @@ async function main() {
         }
 
         if (subArgs[0] === 'view' && subArgs[1]) {
-          await viewIssue(subArgs[1], { json: args.includes('--json'), sync: args.includes('--fetch') });
+          await viewIssue(subArgs[1], { json: args.includes('--json'), local: args.includes('--local') });
         } else if (subArgs[0] === 'sync' && subArgs[1]) {
           await syncJiraProject(subArgs[1], { clean: args.includes('--clean') });
         } else {
@@ -874,7 +879,7 @@ async function main() {
       default:
         // Check if it's an issue key (e.g., ABC-123)
         if (/^[A-Z]+-\d+$/.test(command)) {
-          await viewIssue(command, { json: args.includes('--json'), sync: args.includes('--fetch') });
+          await viewIssue(command, { json: args.includes('--json'), local: args.includes('--local') });
         } else {
           console.error(`Unknown command: ${command}`);
           console.log('Run "ji help" for usage information');

--- a/src/test/command-alias-verification.test.ts
+++ b/src/test/command-alias-verification.test.ts
@@ -106,7 +106,7 @@ test.skip('ji EVAL-5767 and ji issue view EVAL-5767 are identical aliases', asyn
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('ALIAS-123', { json: false, sync: false });
+    await viewIssue('ALIAS-123', { json: false, local: true });
   } finally {
     console.log = originalLog;
   }
@@ -155,7 +155,7 @@ test.skip('ji EVAL-5767 and ji issue view EVAL-5767 are identical aliases', asyn
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('ALIAS-123', { json: false, sync: false });
+    await viewIssue('ALIAS-123', { json: false, local: true });
   } finally {
     console.log = originalLog;
   }

--- a/src/test/ji-issue-view-integration.test.ts
+++ b/src/test/ji-issue-view-integration.test.ts
@@ -127,7 +127,7 @@ test.skip('ji EVAL-5767 command - real issue viewing with comments array process
     const { viewIssue } = await import('../cli/commands/issue');
 
     // This is the actual function that runs when you type `ji EVAL-5767`
-    await viewIssue('EVAL-5767', { json: false, sync: false });
+    await viewIssue('EVAL-5767', { json: false, local: true });
 
     const output = consoleLogs.join('\n');
 
@@ -237,7 +237,7 @@ test.skip('ji EVAL-5767 command - handles issues with no comments', async () => 
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('EVAL-1234', { json: false, sync: false });
+    await viewIssue('EVAL-1234', { json: false, local: true });
 
     const output = consoleLogs.join('\n');
 
@@ -320,7 +320,7 @@ test.skip('ji EVAL-5767 command - handles issues with empty comments array', asy
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('EVAL-5678', { json: false, sync: false });
+    await viewIssue('EVAL-5678', { json: false, local: true });
 
     const output = consoleLogs.join('\n');
 


### PR DESCRIPTION
## Summary

This PR introduces breaking changes to the issue viewing behavior and output format:

- **Remote-first by default**: Issue viewing now fetches fresh data from Jira by default instead of using cached data
- **New `--local` flag**: Added `--local` flag to access cached data when needed (replaces the previous default behavior)
- **XML output format**: Changed output format from YAML to XML for better LLM parsing and structured data handling
- **Updated documentation**: README updated to reflect the new hybrid approach and XML format

## Breaking Changes

### 1. Default Behavior Change
- **Before**: `ji PROJ-123` used cached data by default (local-first)
- **After**: `ji PROJ-123` fetches fresh data from Jira (remote-first)
- **Migration**: Use `ji PROJ-123 --local` for the previous cached behavior

### 2. Flag Changes
- **Removed**: `--fetch` flag (fetching is now the default)
- **Added**: `--local` flag for cached data access

### 3. Output Format Change
- **Before**: YAML format output
- **After**: XML format output optimized for LLM parsing
- **Impact**: Scripts or tools parsing the output will need updates

## Technical Details

### XML Output Benefits
- Better structured data representation for LLMs
- Proper escaping of special characters
- Cleaner hierarchical data structure
- Improved parsing reliability

### Implementation Changes
- Added `escapeXml()` helper function for proper XML character escaping
- Updated `formatIssueOutputEffect()` to generate XML instead of YAML
- Modified parameter handling from `sync` to `local` flag
- Updated help text and documentation
- Fixed test cases to match new parameter names

### Files Modified
- `src/cli/commands/issue.ts` - Core formatting and logic changes
- `src/cli/index.ts` - CLI interface and help text updates  
- `README.md` - Documentation updates
- Test files - Parameter name updates for new flag

## Test Plan

- [x] Verify `ji PROJ-123` fetches fresh data by default
- [x] Verify `ji PROJ-123 --local` uses cached data
- [x] Confirm XML output format is valid and properly escaped
- [x] Test that existing functionality (comments, labels, etc.) works in XML format
- [x] Verify help text shows correct flag usage
- [x] Confirm breaking change impact is documented

🤖 Generated with [Claude Code](https://claude.ai/code)