### PR TITLE
feat: auto-detect AI tools during setup and enhance analyze docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The analyze command:
 - Outputs clean analysis text by default
 - Use `--comment` flag to post as Jira comment
 - Auto-detects available AI tools or uses configured preference
+- **Works best when run from the code directory/repo related to the Jira issue** for context-aware analysis
 
 #### Custom Analysis Prompts
 

--- a/src/assets/default-analysis-prompt.md
+++ b/src/assets/default-analysis-prompt.md
@@ -2,19 +2,21 @@
 
 Analyze the following JIRA issue and comments. Identify the root cause and propose a solution approach.
 
-## Code location
+## Code Context
 
-We are likely either in the relevant repository or in a parent folder which contains the relevant repository.
+**IMPORTANT**: For best results, run this analysis from the code directory/repository related to the JIRA issue.
+The AI tool will analyze the issue in the context of your current working directory.
+If you're not in the relevant codebase, the analysis may be less accurate.
 
 ## Required Analysis
 
 Begin your response with
-🤖 LLM Tool
+🤖 LLM Tool (Model)
 to indicate this is an automated analysis.
 e.g.
-🤖 Claude Code
+🤖 Claude Code (Sonnet 4)
 or
-🤖 Gemini
+🤖 Gemini (Gemini 2.5 Flash)
 
 When it is wrong, disagree with previous analysis.
 
@@ -22,9 +24,10 @@ It is more important to be correct than to agree with previous analysis.
 
 Provide the following sections using plain text formatting:
 - Summary: State the core issue in 1-2 sentences. Note agreement or disagreement with previous analysis.
-- Affected components: List specific Canvas modules/services impacted
-- Key files: Identify 3-5 files most likely requiring modification using repo-relative paths only (e.g., `app/controllers/`, `app/models/`, `lib/api/` - never include machine-specific paths)
+- Affected components: List specific modules/services impacted (adapt to the codebase structure you observe)
+- Key files: Identify 3-5 files most likely requiring modification using repo-relative paths only (examine the actual codebase structure in your current directory)
 - Proposal: Primary fix location and method; data flow changes if applicable; API/database schema impacts, if any
+- Next steps: Concrete actions the developer should take immediately
 
 If possible, answer any unanswered questions asked in Jira issue comments.
 
@@ -55,11 +58,15 @@ h4. Proposal
 * [additional details]
 * [specs to update if applicable]
 
+h4. Next steps
+* [immediate action 1]
+* [immediate action 2]
+
 Output your response in a <response></response> tag. Remember, the contents of this response (inside the <response></response> tags) should start with :robot: with named tool.
 
 ## Example
 
 <response>
-:robot: Gemini
+:robot: Gemini (Gemini 2.5 Flash)
 [the body of the response]
 </response>


### PR DESCRIPTION
## Summary

- Add automatic detection of AI CLI tools (claude, gemini, opencode, ollama) during `ji setup`
- Implement smart defaults: prefer claude if available, otherwise suggest the first detected tool  
- Display detected tools to help users make informed choices
- Update README to note that `ji analyze` works best when run from the relevant code directory/repo

## Features Added

### AI Tool Auto-Detection
- Automatically scans for available AI CLI tools using the `which` command
- Prioritizes tools in order: claude → gemini → opencode → ollama
- Shows detected tools to users during setup for transparency
- Maintains backward compatibility with existing configurations

### Enhanced User Experience
- Smart default suggestions based on what's actually available on the user's system
- Clearer prompts that adapt based on detected tools
- No more guessing which AI tool commands are available

### Documentation Improvement
- Added prominent note in README that `ji analyze` works best from the code directory
- Helps users understand the importance of running analysis from the relevant codebase context

## Technical Details

- Uses Effect-based architecture for robust error handling
- Implements concurrent detection and config loading for better performance
- Graceful fallback to manual input if no tools are detected
- Follows conventional commit message format

## Example Behavior

When running `ji setup`, users now see:
```
Optional: AI Analysis Configuration
Detected AI tools: claude, gemini, opencode, ollama
Analysis tool command [claude]: 
```

🤖 Generated with [Claude Code](https://claude.ai/code)