### PR TITLE
feat: default to pretty colored output for issue view commands

### DIFF
--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -1,8 +1,9 @@
+import chalk from 'chalk';
 import { Console, Effect, pipe } from 'effect';
 import { ConfigManager } from '../../lib/config.js';
 import { type Issue, JiraClient } from '../../lib/jira-client.js';
 import { formatSmartDate } from '../../lib/utils/date-formatter.js';
-import { formatDescription } from '../formatters/issue.js';
+import { formatDescription, getJiraStatusIcon } from '../formatters/issue.js';
 
 // Helper function to escape XML special characters
 function escapeXml(str: string): string {
@@ -52,8 +53,164 @@ const getIssueFromJiraEffect = (jiraClient: JiraClient, issueKey: string) =>
     },
   });
 
+// Effect for formatting issue output in pretty format
+const formatIssueOutputPrettyEffect = (issue: Issue, config: { jiraUrl: string }, jiraClient: JiraClient) =>
+  Effect.tryPromise({
+    try: async () => {
+      // Pretty colored output for human consumption
+      const statusIcon = getJiraStatusIcon(issue.fields.status.name);
+      const statusColor =
+        issue.fields.status.name.toLowerCase().includes('done') ||
+        issue.fields.status.name.toLowerCase().includes('closed') ||
+        issue.fields.status.name.toLowerCase().includes('resolved')
+          ? chalk.green
+          : issue.fields.status.name.toLowerCase().includes('progress')
+            ? chalk.yellow
+            : chalk.blue;
+
+      // Header
+      console.log();
+      console.log(chalk.bold.cyan(`${issue.key}`) + chalk.gray(' - ') + chalk.bold(issue.fields.summary));
+      console.log(chalk.gray(`${config.jiraUrl}/browse/${issue.key}`));
+      console.log();
+
+      // Status and metadata
+      console.log(`${chalk.gray('Status:')}    ${statusIcon}  ${statusColor(issue.fields.status.name)}`);
+      if (issue.fields.priority) {
+        const priorityColor =
+          issue.fields.priority.name.toLowerCase().includes('high') ||
+          issue.fields.priority.name.toLowerCase().includes('critical')
+            ? chalk.red
+            : issue.fields.priority.name.toLowerCase().includes('low')
+              ? chalk.gray
+              : chalk.white;
+        console.log(`${chalk.gray('Priority:')}  ${priorityColor(issue.fields.priority.name)}`);
+      }
+      console.log(`${chalk.gray('Reporter:')}  ${issue.fields.reporter.displayName}`);
+      console.log(
+        `${chalk.gray('Assignee:')}  ${issue.fields.assignee ? issue.fields.assignee.displayName : chalk.gray('Unassigned')}`,
+      );
+      console.log(`${chalk.gray('Created:')}   ${formatSmartDate(issue.fields.created)}`);
+      console.log(`${chalk.gray('Updated:')}   ${formatSmartDate(issue.fields.updated)}`);
+
+      // Epic information
+      const epicField =
+        issue.fields.customfield_10014 ||
+        issue.fields.customfield_10008 ||
+        issue.fields.customfield_10001 ||
+        issue.fields.parent;
+
+      if (epicField) {
+        let epicKey: string | undefined;
+        let epicSummary: string | undefined;
+
+        if (typeof epicField === 'string') {
+          epicKey = epicField;
+        } else if (epicField && typeof epicField === 'object') {
+          const epic = epicField as { key?: string; id?: string; fields?: { summary?: string } };
+          epicKey = epic.key || epic.id;
+          epicSummary = epic.fields?.summary;
+        }
+
+        if (epicKey) {
+          try {
+            const epicIssue = await jiraClient.getIssue(epicKey);
+            if (epicIssue) {
+              epicSummary = epicIssue.fields.summary || epicSummary;
+            }
+          } catch (_error) {
+            // Continue with what we have
+          }
+
+          if (epicKey || epicSummary) {
+            console.log(
+              `${chalk.gray('Epic:')}      ${chalk.magenta(epicKey)}${epicSummary ? chalk.gray(' - ') + epicSummary : ''}`,
+            );
+          }
+        }
+      }
+
+      // Sprint information
+      const sprintField =
+        issue.fields.customfield_10020 ||
+        issue.fields.customfield_10021 ||
+        issue.fields.customfield_10016 ||
+        issue.fields.customfield_10018 ||
+        issue.fields.customfield_10019;
+
+      if (sprintField) {
+        let sprintName = 'Unknown Sprint';
+        if (Array.isArray(sprintField) && sprintField.length > 0) {
+          const sprintInfo = sprintField[0];
+          if (typeof sprintInfo === 'string' && sprintInfo.includes('name=')) {
+            const match = sprintInfo.match(/name=([^,\]]+)/);
+            if (match) sprintName = match[1];
+          } else if (sprintInfo && typeof sprintInfo === 'object' && 'name' in sprintInfo) {
+            sprintName = (sprintInfo as { name: string }).name;
+          }
+        } else if (sprintField && typeof sprintField === 'object' && 'name' in sprintField) {
+          sprintName = (sprintField as { name: string }).name;
+        }
+        console.log(`${chalk.gray('Sprint:')}    ${chalk.cyan(sprintName)}`);
+      }
+
+      // Labels
+      if (issue.fields.labels && issue.fields.labels.length > 0) {
+        console.log(`${chalk.gray('Labels:')}    ${issue.fields.labels.map((l) => chalk.yellow(l)).join(', ')}`);
+      }
+
+      // Description
+      const description = formatDescription(issue.fields.description);
+      if (description.trim() && description !== chalk.gray('No description')) {
+        console.log();
+        console.log(chalk.gray('─'.repeat(60)));
+        console.log(chalk.bold('Description:'));
+        console.log();
+        console.log(description);
+      }
+
+      // Comments
+      if (
+        issue.fields.comment &&
+        typeof issue.fields.comment === 'object' &&
+        'comments' in issue.fields.comment &&
+        Array.isArray((issue.fields.comment as { comments: unknown[] }).comments) &&
+        (issue.fields.comment as { comments: unknown[] }).comments.length > 0
+      ) {
+        const comments = (
+          issue.fields.comment as { comments: { author: { displayName: string }; created: string; body: unknown }[] }
+        ).comments;
+
+        if (comments.length > 0) {
+          console.log();
+          console.log(chalk.gray('─'.repeat(60)));
+          console.log(chalk.bold(`Comments (${comments.length}):`));
+          console.log();
+
+          comments.forEach((comment, index) => {
+            const commentBody = formatDescription(comment.body);
+            console.log(
+              chalk.gray(`[${index + 1}]`) +
+                ' ' +
+                chalk.cyan(comment.author.displayName) +
+                chalk.gray(' • ') +
+                chalk.gray(formatSmartDate(comment.created)),
+            );
+            console.log(commentBody);
+            if (index < comments.length - 1) {
+              console.log();
+            }
+          });
+        }
+      }
+
+      console.log();
+    },
+    catch: (error) => new Error(`Failed to format issue output: ${error}`),
+  });
+
 // Effect for formatting issue output in XML format for better LLM parsing
-const formatIssueOutputEffect = (issue: Issue, config: { jiraUrl: string }, jiraClient: JiraClient) =>
+const formatIssueOutputXmlEffect = (issue: Issue, config: { jiraUrl: string }, jiraClient: JiraClient) =>
   Effect.tryPromise({
     try: async () => {
       // XML output for better LLM parsing
@@ -240,7 +397,7 @@ const formatIssueOutputEffect = (issue: Issue, config: { jiraUrl: string }, jira
   });
 
 // Pure Effect-based viewIssue implementation - API-only approach
-const viewIssueEffect = (issueKey: string) =>
+const viewIssueEffect = (issueKey: string, options: { xml?: boolean }) =>
   pipe(
     getConfigEffect(),
     Effect.flatMap(({ config, configManager, jiraClient }) =>
@@ -249,7 +406,9 @@ const viewIssueEffect = (issueKey: string) =>
         getIssueFromJiraEffect(jiraClient, issueKey),
         Effect.flatMap((issue) =>
           pipe(
-            formatIssueOutputEffect(issue, config, jiraClient),
+            options.xml
+              ? formatIssueOutputXmlEffect(issue, config, jiraClient)
+              : formatIssueOutputPrettyEffect(issue, config, jiraClient),
             Effect.tap(() =>
               Effect.sync(() => {
                 configManager.close();
@@ -267,9 +426,11 @@ const viewIssueEffect = (issueKey: string) =>
     ),
   );
 
-export async function viewIssue(issueKey: string, _options: { json?: boolean } = {}) {
+export async function viewIssue(issueKey: string, options: { json?: boolean; xml?: boolean } = {}) {
   try {
-    await Effect.runPromise(viewIssueEffect(issueKey));
+    // Support legacy --json flag as alias for --xml
+    const xmlOutput = options.xml || options.json;
+    await Effect.runPromise(viewIssueEffect(issueKey, { xml: xmlOutput }));
   } catch (_error) {
     process.exit(1);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,14 +49,16 @@ ${chalk.yellow('Subcommands:')}
 
 
 ${chalk.yellow('Options:')}
-  --json                    Output in JSON format (for view)
-
+  --xml                     Output in XML format for LLM parsing
+  --json                    Alias for --xml (deprecated)
   --help                    Show this help message
 
 ${chalk.yellow('Note:')}
-  By default, 'ji issue view' fetches fresh data from Jira.
+  By default, 'ji issue view' shows pretty colored output.
+  Use --xml for LLM-friendly XML output.
 ${chalk.yellow('Examples:')}
-  ji issue view EVAL-123    # View issue details
+  ji issue view EVAL-123    # View issue with pretty output
+  ji issue view EVAL-123 --xml # View issue in XML format
   ji sprint ABC             # Show current sprint for project ABC
 `);
 }
@@ -434,7 +436,8 @@ ${chalk.yellow('Issues:')}
   ji comment <issue-key> [comment]     Add a comment to an issue
   ji analyze <issue-key-or-url>        Analyze issue with AI
   ji log <issue-key>                   Interactive comment viewer/editor
-  ji <issue-key>                       View issue (fetches fresh data)
+  ji <issue-key>                       View issue (pretty output by default)
+  ji <issue-key> --xml                 View issue in XML format
 
   ji issue view <issue-key>            View issue details (alias)
   ji issue sync <project-key>          Sync all issues from a project
@@ -452,7 +455,8 @@ ${chalk.yellow('Help:')}
   ji [command] --help                  Show help for a specific command
 
 ${chalk.gray('Examples:')}
-  ji ABC-123                           View issue ABC-123
+  ji ABC-123                           View issue with pretty colors
+  ji ABC-123 --xml                    View issue in XML format
   ji mine                              Show your assigned issues
   ji mine --status "In Progress"      Filter by status
   ji analyze ABC-123                   Analyze issue with AI
@@ -643,7 +647,7 @@ async function main() {
         }
 
         if (subArgs[0] === 'view' && subArgs[1]) {
-          await viewIssue(subArgs[1], { json: args.includes('--json') });
+          await viewIssue(subArgs[1], { xml: args.includes('--xml'), json: args.includes('--json') });
         } else {
           console.error('Invalid issue command. Use "ji issue view <key>"');
           showIssueHelp();
@@ -774,7 +778,7 @@ async function main() {
       default:
         // Check if it's an issue key (e.g., ABC-123)
         if (/^[A-Z]+-\d+$/.test(command)) {
-          await viewIssue(command, { json: args.includes('--json') });
+          await viewIssue(command, { xml: args.includes('--xml'), json: args.includes('--json') });
         } else {
           console.error(`Unknown command: ${command}`);
           console.log('Run "ji help" for usage information');

--- a/src/test/command-alias-verification.test.ts
+++ b/src/test/command-alias-verification.test.ts
@@ -120,7 +120,7 @@ test('ji EVAL-5767 and ji issue view EVAL-5767 are identical aliases', async () 
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('ALIAS-123', { json: false, local: true });
+    await viewIssue('ALIAS-123', { xml: true, local: true });
   } finally {
     console.log = originalLog;
   }
@@ -169,7 +169,7 @@ test('ji EVAL-5767 and ji issue view EVAL-5767 are identical aliases', async () 
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('ALIAS-123', { json: false, local: true });
+    await viewIssue('ALIAS-123', { xml: true, local: true });
   } finally {
     console.log = originalLog;
   }

--- a/src/test/ji-issue-view-integration.test.ts
+++ b/src/test/ji-issue-view-integration.test.ts
@@ -146,7 +146,7 @@ test('ji EVAL-5767 command - real issue viewing with comments array processing',
     const { viewIssue } = await import('../cli/commands/issue');
 
     // This is the actual function that runs when you type `ji EVAL-5767`
-    await viewIssue('EVAL-5767', { json: false });
+    await viewIssue('EVAL-5767', { xml: true });
 
     const output = consoleLogs.join('\n');
 
@@ -255,7 +255,7 @@ test('ji EVAL-5767 command - handles issues with no comments', async () => {
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('EVAL-1234', { json: false });
+    await viewIssue('EVAL-1234', { xml: true });
 
     const output = consoleLogs.join('\n');
 
@@ -338,7 +338,7 @@ test('ji EVAL-5767 command - handles issues with empty comments array', async ()
 
   try {
     const { viewIssue } = await import('../cli/commands/issue');
-    await viewIssue('EVAL-5678', { json: false });
+    await viewIssue('EVAL-5678', { xml: true });
 
     const output = consoleLogs.join('\n');
 


### PR DESCRIPTION
## Summary
- Changed issue view commands to show pretty colored output by default
- Made XML output opt-in via the `--xml` flag
- Maintained backward compatibility with `--json` as alias for `--xml`

## Changes Made

### Issue View Output
- **Before**: Issue view showed XML output by default (optimized for LLM parsing)
- **After**: Issue view shows human-friendly colored output by default
  - Pretty formatting with colors, icons, and structured layout
  - XML output available via `--xml` flag for LLM consumption
  
### Commands Affected
- `ji issue view CFA-99` - Shows pretty output by default
- `ji CFA-99` - Shows pretty output by default (shorthand)
- `ji issue view CFA-99 --xml` - Shows XML output when flag is used
- `ji CFA-99 --xml` - Shows XML output when flag is used

### Pretty Output Features
- 🎨 Colored status indicators and metadata
- 📋 Status icons (✅ done, 🔄 in progress, 📋 todo, etc.)
- Structured layout with clear sections
- Readable formatting for descriptions and comments
- Smart date formatting showing relative times

## Test Plan
- [x] Tested `ji issue view CFA-99` shows pretty output
- [x] Tested `ji issue view CFA-99 --xml` shows XML output
- [x] Tested `ji CFA-99` shows pretty output  
- [x] Tested `ji CFA-99 --xml` shows XML output
- [x] All existing tests pass
- [x] TypeScript and linting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)