### PR TITLE
refactor: remove custom prompt file setting from setup command

### DIFF
--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -270,8 +270,8 @@ const loadPrompt = (promptPath?: string): Effect.Effect<string, ConfigurationErr
       });
     }
 
-    // Check config for default prompt
-    const config = yield* Effect.tryPromise<Config | null, null>({
+    // Check config for default prompt (removed analysisPrompt support)
+    yield* Effect.tryPromise<Config | null, null>({
       try: async () => {
         const configManager = new ConfigManager();
         try {
@@ -282,22 +282,6 @@ const loadPrompt = (promptPath?: string): Effect.Effect<string, ConfigurationErr
       },
       catch: () => null,
     });
-
-    if (config?.analysisPrompt) {
-      const promptPath = config.analysisPrompt;
-      const expandedPath = expandTilde(promptPath);
-      if (!existsSync(expandedPath)) {
-        return yield* Effect.fail(
-          new ConfigurationError(
-            `Configured analysis prompt file not found: ${promptPath}\nPlease run "ji setup" to update the configuration.`,
-          ),
-        );
-      }
-      return yield* Effect.try({
-        try: () => readFileSync(expandedPath, 'utf-8'),
-        catch: (error) => new ConfigurationError(`Failed to read config prompt: ${error}`),
-      });
-    }
 
     // Use default prompt
     const defaultPromptPath = join(import.meta.dir, '../../assets/default-analysis-prompt.md');

--- a/src/lib/config.effect.test.ts
+++ b/src/lib/config.effect.test.ts
@@ -31,7 +31,6 @@ describe('ConfigManager Effect-based Tests', () => {
         email: 'test@example.com',
         apiToken: 'test-token-123',
         analysisCommand: 'claude',
-        analysisPrompt: '/path/to/prompt.md',
       };
 
       await configManager.setConfig(validConfig);
@@ -165,7 +164,6 @@ describe('ConfigManager Effect-based Tests', () => {
         expect(result.value.email).toBe('minimal@example.com');
         expect(result.value.apiToken).toBe('minimal-token');
         expect(result.value.analysisCommand).toBeUndefined();
-        expect(result.value.analysisPrompt).toBeUndefined();
       }
     });
   });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -24,7 +24,6 @@ const ConfigSchema = Schema.Struct({
   jiraUrl: Schema.String.pipe(Schema.pattern(/^https?:\/\/.+/)), // URL validation
   email: Schema.String.pipe(Schema.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)), // Email validation
   apiToken: Schema.String.pipe(Schema.minLength(1)),
-  analysisPrompt: Schema.optional(Schema.String), // Path to analysis prompt file
   analysisCommand: Schema.optional(Schema.String), // Command for analysis tool (e.g., "claude -p")
   defaultProject: Schema.optional(Schema.String), // Default project key (e.g., "PROJ")
 });

--- a/src/test/analyze-command.test.ts
+++ b/src/test/analyze-command.test.ts
@@ -22,7 +22,6 @@ const TestConfigSchema = Schema.Struct({
   jiraUrl: Schema.String,
   email: Schema.String,
   apiToken: Schema.String,
-  analysisPrompt: Schema.optional(Schema.String),
   analysisCommand: Schema.optional(Schema.String),
 });
 
@@ -47,7 +46,6 @@ const createMockConfig = (overrides?: Partial<Config>): Config => {
     jiraUrl: 'https://test.atlassian.net',
     email: 'test@example.com',
     apiToken: 'test-token',
-    analysisPrompt: '/path/to/prompt.md',
     analysisCommand: 'claude -p',
     ...overrides,
   };
@@ -640,8 +638,8 @@ describe.skip('Analyze Command with Effect and MSW', () => {
         }),
       }));
 
-      // Remove analysisPrompt from config
-      mockConfig = createMockConfig({ analysisPrompt: undefined });
+      // Remove analysisCommand from config
+      mockConfig = createMockConfig({ analysisCommand: undefined });
 
       installFetchMock(createMockApiHandler());
       mockToolExecution('<response>Test</response>');

--- a/src/test/effect-test-helpers.ts
+++ b/src/test/effect-test-helpers.ts
@@ -212,7 +212,6 @@ interface TestConfig {
   email: string;
   apiToken: string;
   analysisCommand?: string;
-  analysisPrompt?: string;
 }
 
 export class ConfigBuilder {
@@ -239,11 +238,6 @@ export class ConfigBuilder {
 
   withAnalysisCommand(command: string): this {
     this.config.analysisCommand = command;
-    return this;
-  }
-
-  withAnalysisPrompt(prompt: string): this {
-    this.config.analysisPrompt = prompt;
     return this;
   }
 


### PR DESCRIPTION
## Summary
- Removed the `analysisPrompt` field from the configuration schema
- Simplified the setup command by removing prompt file configuration
- Users can still use custom prompts via the `--prompt` flag when running commands

## Breaking Change
Custom prompt file configuration has been removed from the setup command. Users who want to use custom prompts should now use the `--prompt` flag when running analyze commands:

```bash
ji analyze ISSUE-123 --prompt ./my-prompt.md
```

## Changes Made
- Removed `analysisPrompt` field from ConfigSchema
- Updated setup command to remove prompt file validation and input
- Updated all tests to reflect the removal
- Cleaned up unused imports and code

## Test Plan
- [x] All tests pass (`bun test`)
- [x] TypeScript compilation succeeds (`bun run typecheck`)
- [x] Linting passes (`bun run lint`)
- [x] Pre-commit hooks pass