### PR TITLE
Fix: enforce robot header in analysis comments for proper Jira formatting

### DIFF
--- a/src/assets/default-analysis-prompt.md
+++ b/src/assets/default-analysis-prompt.md
@@ -10,13 +10,17 @@ If you're not in the relevant codebase, the analysis may be less accurate.
 
 ## Required Analysis
 
-Begin your response with
-🤖 LLM Tool (Model)
-to indicate this is an automated analysis.
-e.g.
-🤖 Claude Code (Sonnet 4)
-or
-🤖 Gemini (Gemini 2.5 Flash)
+**CRITICAL REQUIREMENT**: Your response MUST begin with the robot header to indicate this is an automated analysis.
+
+**MANDATORY FORMAT**: Begin your response with exactly:
+:robot: [Tool Name] ([Model Name])
+
+Examples:
+:robot: Claude Code (Sonnet 4)
+:robot: Gemini (Gemini 2.5 Flash)
+:robot: OpenCode (GPT-4)
+
+**DO NOT** use the emoji 🤖 - use the text :robot: which will be converted automatically.
 
 When it is wrong, disagree with previous analysis.
 
@@ -62,7 +66,7 @@ h4. Next steps
 * [immediate action 1]
 * [immediate action 2]
 
-Output your response in an opening <ji-response> and closing </ji-response> tag. Remember, the contents of this response (inside the <ji-response> tags) should start with :robot: with named tool.
+**CRITICAL**: Output your response in an opening <ji-response> and closing </ji-response> tag. The contents inside the tags MUST start with :robot: [Tool Name] ([Model Name]) as shown in the examples above.
 
 ## Example
 

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -634,13 +634,16 @@ const analyzeIssueEffect = (
     const fullIssueXml = commentsXml ? issueXml.replace('</issue>', `${commentsXml}</issue>`) : issueXml;
 
     // Build input for tool
-    const systemPrompt = `CRITICAL FORMATTING REQUIREMENT:
+    const systemPrompt = `CRITICAL FORMATTING REQUIREMENTS:
 
-Your ENTIRE response must be wrapped in opening <ji-response> and closing </ji-response> tags EXACTLY like this:
+1. Your ENTIRE response must be wrapped in opening <ji-response> and closing </ji-response> tags EXACTLY like this:
 
 <ji-response>
 Your analysis goes here...
 </ji-response>
+
+2. The content inside the tags MUST start with the robot header in this exact format:
+:robot: [Tool Name] ([Model Name])
 
 REQUIREMENTS:
 - Use lowercase "ji-response" (not JI-Response, JI-RESPONSE, or ji-response with attributes)
@@ -648,16 +651,21 @@ REQUIREMENTS:
 - Put ALL content between the tags
 - Do NOT include any text before <ji-response> or after </ji-response>
 - The tags must be on their own lines
+- The first line inside the tags MUST be the robot header
 
 EXAMPLE:
 <ji-response>
-## Analysis
+:robot: Claude Code (Sonnet 4)
+
+h4. Summary
 This issue appears to...
 
-## Recommendations
+h4. Next steps
 1. First step...
 2. Second step...
 </ji-response>
+
+MANDATORY: The robot header is required for proper comment formatting in Jira.
 
 `;
     const fullInput = `${systemPrompt}\n\n${prompt}\n\n${fullIssueXml}`;


### PR DESCRIPTION
## Summary
- Update default analysis prompt to make robot header requirement more explicit
- Add stronger system prompt in analyze command to enforce `:robot:` header format
- Ensures analysis comments display with proper "🤖 Tool Name (Model)" attribution in Jira

## Problem
Analysis comments posted to Jira were missing the robot icon and tool attribution at the top. The analysis tools weren't following the prompt instructions to include the required `:robot:` header format.

## Solution
- Enhanced the default analysis prompt with more explicit formatting requirements
- Added stronger system prompt in the analyze command to enforce the robot header
- Made the requirement more prominent with **CRITICAL** and **MANDATORY** emphasis

## Test plan
- [x] Run `ji analyze ISSUE-KEY --comment` with updated prompts
- [x] Verify analysis tool includes `:robot:` header in response
- [x] Verify comment appears in Jira with proper "🤖 Tool Name (Model)" formatting
- [x] Confirm existing comment formatting logic correctly converts `:robot:` to 🤖

🤖 Generated with [Claude Code](https://claude.ai/code)