### PR TITLE
fix: improve robot header format examples in analysis prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaronshaf/ji",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Jira CLI with LLM-friendly output",
   "type": "module",
   "bin": {

--- a/src/assets/default-analysis-prompt.md
+++ b/src/assets/default-analysis-prompt.md
@@ -15,8 +15,14 @@ If you're not in the relevant codebase, the analysis may be less accurate.
 **MANDATORY FORMAT**: Begin your response with exactly:
 :robot: [Tool Name] ([Model Name])
 
-Format:
-:robot: [Your Tool Name] ([Your Model Name])
+**CORRECT EXAMPLES**:
+:robot: Claude Code (Sonnet 4)
+:robot: Gemini CLI (1.5 Pro) 
+:robot: ChatGPT Plus (GPT-4)
+
+**WRONG FORMAT** (do not use):
+:robot: [Claude Code (Sonnet 4)]
+:robot: [Gemini (1.5 Pro)]
 
 **DO NOT** use the emoji 🤖 - use the text :robot: which will be converted automatically.
 
@@ -69,6 +75,27 @@ h4. Next steps
 ## Example Format
 
 <ji-response>
-:robot: [Your Tool Name] ([Your Model Name])
-[the body of the response]
+:robot: Claude Code (Sonnet 4)
+
+h4. Summary
+The line spacing inconsistency arises because the Comment Library uses a standard `<textarea>` element, while the main comment field is a TinyMCE rich text editor. Newlines in a `<textarea>` are rendered differently than the `<p>` tags used by TinyMCE for paragraphs, causing a visual mismatch in the line-height during comment composition.
+
+h4. Affected components
+* SpeedGrader
+* Comment Library
+
+h4. Key files
+* `app/views/shared/media_comment_form.html.erb`: This file contains the main media comment form, including the TinyMCE editor instance used for submission comments in SpeedGrader.
+* `ui/src/apps/speedgrader/CommentLibrary/CommentLibraryForm.tsx`: This React component renders the form for adding or editing a comment within the Comment Library, which includes the `<textarea>` element with the inconsistent spacing.
+* `ui/src/apps/speedgrader/CommentLibrary/CommentLibraryManager.tsx`: The parent component that manages the state and functionality of the Comment Library, including rendering the `CommentLibraryForm`.
+
+h4. Proposal
+* Replace the `<textarea>` in CommentLibraryForm with a TinyMCE instance to maintain consistency
+* Alternatively, standardize line-height CSS properties between both editors
+* Update CommentLibraryManager to handle rich text content from the Comment Library
+
+h4. Next steps
+* Examine the TinyMCE configuration in media_comment_form.html.erb
+* Update CommentLibraryForm.tsx to use TinyMCE or match its styling
+* Test comment rendering consistency between both interfaces
 </ji-response>

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -649,6 +649,15 @@ Your analysis goes here...
 2. The content inside the tags MUST start with the robot header in this exact format:
 :robot: [Tool Name] ([Model Name])
 
+CORRECT EXAMPLES of robot header:
+:robot: Claude Code (Sonnet 4)
+:robot: Gemini CLI (1.5 Pro)
+:robot: ChatGPT Plus (GPT-4)
+
+WRONG FORMAT (do not use):
+:robot: [Claude Code (Sonnet 4)]
+:robot: [Gemini (1.5 Pro)]
+
 REQUIREMENTS:
 - Use lowercase "ji-response" (not JI-Response, JI-RESPONSE, or ji-response with attributes)
 - Include BOTH opening <ji-response> and closing </ji-response> tags
@@ -659,7 +668,7 @@ REQUIREMENTS:
 
 EXAMPLE FORMAT:
 <ji-response>
-:robot: [Your Tool Name] ([Your Model Name])
+:robot: Claude Code (Sonnet 4)
 
 h4. Summary
 This issue appears to...


### PR DESCRIPTION
## Summary
- Improve robot header format examples in analysis prompts to guide AI models toward the correct format
- Add clear examples showing correct format: `:robot: Tool Name (Model Name)`
- Show wrong format examples to avoid: `:robot: [Tool (Model)]`

## Changes
- Updated `src/assets/default-analysis-prompt.md` with concrete examples and wrong format warnings
- Updated `src/cli/commands/analyze.ts` system prompt with the same examples
- Replaced generic placeholders with specific examples like "Claude Code (Sonnet 4)"

## Test plan
- [x] TypeScript compilation passes
- [x] Linting passes  
- [x] All tests pass
- [ ] Test analysis tool output format with updated prompts

🤖 Generated with [Claude Code](https://claude.ai/code)