### PR TITLE
fix: add JSX pragma to prevent CWD tsconfig interference

### DIFF
--- a/src/cli/commands/log.tsx
+++ b/src/cli/commands/log.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource react */
 import chalk from 'chalk';
 import { Effect, pipe } from 'effect';
 import { Box, render, Text, useApp, useInput } from 'ink';


### PR DESCRIPTION
When running ji from directories with custom jsxImportSource configs (e.g. @emotion/react), Bun would use the CWD's tsconfig instead of ji's, causing module resolution errors.

Added `/** @jsxImportSource react */` pragma to log.tsx to override any CWD tsconfig and ensure consistent JSX runtime resolution.

Test plan:
1. Create test dir: `mkdir /tmp/test-ji && cd /tmp/test-ji`
2. Add emotion config: `echo '{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"@emotion/react"}}' > tsconfig.json`
3. Run: `~/path/to/ji/src/cli.ts --help`
4. Should work (without pragma: "Cannot find module '@emotion/react/jsx-dev-runtime'")