### PR TITLE
fix: add JSX pragma to prevent CWD tsconfig interference

### DIFF
--- a/src/cli/commands/log.tsx
+++ b/src/cli/commands/log.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource react */
 import chalk from 'chalk';
 import { Effect, pipe } from 'effect';
 import { Box, render, Text, useApp, useInput } from 'ink';


### PR DESCRIPTION
## Summary
- Fixes JSX module resolution errors when running `ji` from directories with custom tsconfig.json
- Adds `/** @jsxImportSource react */` pragma to log.tsx to ensure consistent JSX runtime

## Problem
When running ji from directories with custom `jsxImportSource` configs (e.g. `@emotion/react`), Bun would use the CWD's tsconfig instead of ji's, causing module resolution errors like:
```
Cannot find module '@emotion/react/jsx-dev-runtime'
```

## Solution
Added JSX pragma to explicitly override any CWD tsconfig and ensure ji always uses React's JSX runtime.

## Test plan
- [x] Create test directory with emotion config
- [x] Run ji from that directory
- [x] Verify no module resolution errors
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)